### PR TITLE
Don't close tab with middle click if isClosable is false

### DIFF
--- a/src/js/controls/Tab.js
+++ b/src/js/controls/Tab.js
@@ -139,7 +139,7 @@ lm.utils.copy( lm.controls.Tab.prototype,{
 			this.header.parent.setActiveContentItem( this.contentItem );
 
 		// middle mouse button
-		} else if( event.button === 1 ) {
+		} else if( event.button === 1 && this.contentItem.config.isClosable ) {
 			this._onCloseClick( event );
 		}
 	},


### PR DESCRIPTION
The implementation of https://github.com/hoxton-one/golden-layout/issues/7 introduced a minor bug:
One could close a tab with isClosable: false by middle clicking it

This pull request fixes the bug.
