### PR TITLE
Enable close tab with isClosable == true even if showCloseIcon == false

### DIFF
--- a/src/js/controls/Tab.js
+++ b/src/js/controls/Tab.js
@@ -30,7 +30,7 @@ lm.controls.Tab = function( header, contentItem ) {
 
 	this.element.click( this._onTabClickFn );
 
-	if( this._layoutManager.config.settings.showCloseIcon === true ) {
+	if( this.contentItem.config.isClosable ) {
 		this.closeElement.click( this._onCloseClickFn );
 	} else {
 		this.closeElement.remove();


### PR DESCRIPTION
~~With the global setting settings.showCloseIcon set to true~~, I'm not able to close anything. Both the close button in the header is hidden and the close button on all tabs. To me, it makes sense to show a close button for each tab with isClosable == true, even if the global showCloseIcon is false. What I really want is to hide the close button in headers, but still be able to close tabs with isClosable == true.

Close the pull request if you disagree, or if you have a better suggestion for how to cover this requirement.