### PR TITLE
Show splitter even when trying to drag it beyond bounds

### DIFF
--- a/src/css/goldenlayout-dark-theme.css
+++ b/src/css/goldenlayout-dark-theme.css
@@ -28,7 +28,7 @@
 	transition: opacity 200ms ease;
 }
 
-.lm_splitter:hover{
+.lm_splitter:hover, .lm_splitter.lm_dragging{
 	opacity: 1;
 	background: #444;
 }

--- a/src/css/goldenlayout-light-theme.css
+++ b/src/css/goldenlayout-light-theme.css
@@ -30,7 +30,7 @@
 	transition: opacity 200ms ease;
 }
 
-.lm_splitter:hover{
+.lm_splitter:hover, .lm_splitter.lm_dragging{
 	opacity: 1;
 	background: #bbb;
 }

--- a/src/css/goldenlayout-soda-theme.css
+++ b/src/css/goldenlayout-soda-theme.css
@@ -30,7 +30,7 @@
 	transition: opacity 200ms ease;
 }
 
-.lm_splitter:hover{
+.lm_splitter:hover, .lm_splitter.lm_dragging{
 	opacity: 1;
 	background: #444;
 }

--- a/src/js/utils/DragListener.js
+++ b/src/js/utils/DragListener.js
@@ -84,6 +84,7 @@ lm.utils.copy( lm.utils.DragListener.prototype, {
 	{
 		clearTimeout( this._timeout );
 		this._eBody.removeClass( 'lm_dragging' );
+		this._eElement.removeClass( 'lm_dragging' );
 		this._oDocument.unbind( 'mousemove touchmove', this._fMove);
 		
 		if( this._bDragging === true )
@@ -97,6 +98,7 @@ lm.utils.copy( lm.utils.DragListener.prototype, {
 	{
 		this._bDragging = true;
 		this._eBody.addClass( 'lm_dragging' );
+		this._eElement.addClass( 'lm_dragging' );
 		this.emit('dragStart', this._nOriginalX, this._nOriginalY);
 	},
 


### PR DESCRIPTION
While dragging the splitter, it gets an "active" style, i.e. a different color and/or opacity. However, when you try to drag the splitter to a place that is beyond the bounds defined by minItemWidth and minItemHeight, it loses its "active" style. That is a usability problem, and this pull request suggests one way to fix it.