### PR TITLE
Don't force box-sizing

### DIFF
--- a/src/css/goldenlayout-base.css
+++ b/src/css/goldenlayout-base.css
@@ -65,7 +65,7 @@
 	overflow: visible;
 }
 
-.lm_header * {
+.lm_header [class^=lm_] {
 	box-sizing: content-box !important;
 }
 


### PR DESCRIPTION
Only apply box-sizing property for GL's own classes. Don't force it to all inner elements.