### PR TITLE
Fixed three sources of memory leaks when destroying the LayoutManager

### DIFF
--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -24,6 +24,7 @@ lm.LayoutManager = function( config, container ) {
 	this._components = { 'lm-react-component': lm.utils.ReactComponentHandler };
 	this._itemAreas = [];
 	this._resizeFunction = lm.utils.fnBind( this._onResize, this );
+	this._unloadFunction = lm.utils.fnBind( this._onUnload, this );
 	this._maximisedItem = null;
 	this._maximisePlaceholder = $( '<div class="lm_maximise_place"></div>' );
 	this._creationTimeoutPassed = false;
@@ -45,8 +46,6 @@ lm.LayoutManager = function( config, container ) {
 	if( this.isSubWindow === true ) {
 		$( 'body' ).css( 'visibility', 'hidden' );
 	}
-
-	$( window ).on( 'unload beforeunload', lm.utils.fnBind( this._onUnload, this) );
 
 	this._typeToItem = {
 		'column': lm.utils.fnBind( lm.items.RowOrColumn, this, [ true ] ),
@@ -308,6 +307,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		}
 		this._onUnload();
 		$( window ).off( 'resize', this._resizeFunction );
+		$( window ).off( 'unload beforeunload', this._unloadFunction );
 		this.root.callDownwards( '_$destroy', [], true );
 		this.root.contentItems = [];
 		this.tabDropPlaceholder.remove();
@@ -720,6 +720,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		if( this._isFullPage ) {
 			$(window).resize( this._resizeFunction );
 		}
+		$(window).on( 'unload beforeunload', this._unloadFunction );
 	},
 
 	/**

--- a/src/js/LayoutManager.js
+++ b/src/js/LayoutManager.js
@@ -313,6 +313,7 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		this.tabDropPlaceholder.remove();
 		this.dropTargetIndicator.destroy();
 		this.transitionIndicator.destroy();
+		this.eventHub.destroy();
 	},
 
 	/**

--- a/src/js/controls/Tab.js
+++ b/src/js/controls/Tab.js
@@ -102,6 +102,10 @@ lm.utils.copy( lm.controls.Tab.prototype,{
 	_$destroy: function() {
 		this.element.off( 'click', this._onTabClickFn );
 		this.closeElement.off( 'click', this._onCloseClickFn );
+		if( this._dragListener ) {
+			this._dragListener.off( 'dragStart', this._onDragStart );
+			this._dragListener = null;
+		}
 		this.element.remove();
 	},
 

--- a/src/js/utils/EventHub.js
+++ b/src/js/utils/EventHub.js
@@ -19,7 +19,8 @@ lm.utils.EventHub = function( layoutManager ) {
 	this._dontPropagateToParent = null;
 	this._childEventSource = null;
 	this.on( lm.utils.EventEmitter.ALL_EVENT, lm.utils.fnBind( this._onEventFromThis, this ) );
-	$(window).on( 'gl_child_event', lm.utils.fnBind( this._onEventFromChild, this ) );
+	this._boundOnEventFromChild = lm.utils.fnBind( this._onEventFromChild, this );
+	$(window).on( 'gl_child_event', this._boundOnEventFromChild );
 };
 
 /**
@@ -119,4 +120,16 @@ lm.utils.EventHub.prototype._propagateToChildren = function( args ) {
 			childGl.eventHub._$onEventFromParent( args );
 		}
 	}
+};
+
+
+/**
+ * Destroys the EventHub
+ *
+ * @public
+ * @returns {void}
+ */
+
+lm.utils.EventHub.prototype.destroy = function() {
+	$(window).off( 'gl_child_event', this._boundOnEventFromChild );
 };


### PR DESCRIPTION
I first saw that repeatedly creating and destroying a LayoutManager object made the heap memory size grow over time. I did some investigation using heap snapshots and found that some DOM events were not unsubscribed when destroying the LayoutManager. This pull request fixes three cases that I have been able to locate.

After these three changes, memory does not seem to grow as much anymore and there is no more detached DOM tree in the heap snapshots.

Thanks for this great library!