### PR TITLE
Add position:relative to .lm_content to enable absolute positioning within the panels

### DIFF
--- a/src/css/goldenlayout-base.css
+++ b/src/css/goldenlayout-base.css
@@ -8,6 +8,7 @@
 
 .lm_content{
 	overflow: hidden;
+	position: relative;
 }
 
 .lm_dragging, .lm_dragging *{


### PR DESCRIPTION
This pull-request will fix an issue with absolute positioned elements in one of the panels in case there is a two row layout with multiple columns inside.

**ISSUE:**
![Missing position: relative on lm_content](https://cloud.githubusercontent.com/assets/3659792/17815759/159c9fde-6636-11e6-8e2d-9429c57650c3.png)


**FIX:**
![Added position: relative on lm_content](https://cloud.githubusercontent.com/assets/3659792/17815838/535c8f50-6636-11e6-9402-ed91290df175.png)
