### PR TITLE
Added getElement() to Container interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -622,7 +622,12 @@ declare namespace GoldenLayout {
          * Returns the current state.
          */
         getState(): any;
-
+        
+        /**
+          * Returns the container's inner element as a jQuery element 
+          */
+        getElement():JQuery
+        
         /**
          * hides the container or returns false if hiding it is not possible
          */


### PR DESCRIPTION
Add missing getElement() to Container interface's typescript definition closes #155