### PR TITLE
Added preventDrag config item to prevent dragging of tabs

### DIFF
--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -2618,6 +2618,10 @@ lm.utils.copy( lm.controls.Tab.prototype,{
 	 * @returns {void}
 	 */
 	_onDragStart: function( x, y ) {
+		if( this.contentItem.config.preventDrag === true ) {
+			return;
+		}
+		
 		if( this.contentItem.parent.isMaximised === true ) {
 			this.contentItem.parent.toggleMaximise();
 		}


### PR DESCRIPTION
By adding preventDrag to the config, the drag proxy will not fire, the user will no longer be able to drag move the element.
However other components can be moved around it so in theory, by moving everything else you can change the position of the component.

I am not preventing the event handler bind to allow for this to be changed dynamically.