### PR TITLE
Passing "this" to destroy so we know what is destroyed

### DIFF
--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -2312,7 +2312,7 @@ lm.utils.copy( lm.controls.Header.prototype, {
 	 * @returns {void}
 	 */
 	_$destroy: function() {
-		this.emit( 'destroy' );
+		this.emit( 'destroy', this );
 	
 		for( var i = 0; i < this.tabs.length; i++ ) {
 			this.tabs[ i ]._$destroy();
@@ -3424,7 +3424,7 @@ lm.utils.copy( lm.items.Component.prototype, {
 	},
 
 	_$destroy: function() {
-		this.container.emit( 'destroy' );
+		this.container.emit( 'destroy', this );
 		lm.items.AbstractContentItem.prototype._$destroy.call( this );
 	},
 


### PR DESCRIPTION
By passing the "**this**" variable, we can now see what element was destroyed. Knowing that _something_ was destroyed isn't very useful compared to know _what_ was destroyed.