### PR TITLE
Do not update size of hidden components to prevent unwanted reflows

### DIFF
--- a/src/js/items/Component.js
+++ b/src/js/items/Component.js
@@ -31,7 +31,10 @@ lm.utils.copy( lm.items.Component.prototype, {
 	},
 
 	setSize: function() {
-		this.container._$setSize( this.element.width(), this.element.height() );
+		if( this.element.is( ':visible' ) ) {
+			// Do not update size of hidden components to prevent unwanted reflows
+			this.container._$setSize( this.element.width(), this.element.height() );
+		}
 	},
 
 	_$init: function() {


### PR DESCRIPTION
Open/Close tab performance on Firefox will dramatically decrease with complex hidden HTML. This change seems not to have any visible side effects. See issue #162 .