### PR TITLE
Stopped errors when no event is present

### DIFF
--- a/src/js/items/AbstractContentItem.js
+++ b/src/js/items/AbstractContentItem.js
@@ -241,7 +241,7 @@ lm.utils.copy( lm.items.AbstractContentItem.prototype, {
 	 * @returns {void}
 	 */
 	toggleMaximise: function( e ) {
-		e.preventDefault();
+		e&&e.preventDefault();
 		if( this.isMaximised === true ) {
 			this.layoutManager._$minimiseItem( this );
 		} else {


### PR DESCRIPTION
Because of the jQuery calling nature of GoldenLayout you always expect an event. But when a user calls toggleMaximise from their code it may not be appropriate to pass any event and therefore no need to prevent any default action.