### PR TITLE
add borderGrabWidth config, also fixes issue #240

### DIFF
--- a/src/js/config/defaultConfig.js
+++ b/src/js/config/defaultConfig.js
@@ -15,6 +15,7 @@ lm.config.defaultConfig = {
 	},
 	dimensions: {
 		borderWidth: 5,
+		borderGrabWidth: 15,
 		minItemHeight: 10,
 		minItemWidth: 10,
 		headerHeight: 20,

--- a/src/js/controls/Splitter.js
+++ b/src/js/controls/Splitter.js
@@ -1,6 +1,7 @@
-lm.controls.Splitter = function( isVertical, size ) {
+lm.controls.Splitter = function( isVertical, size, grabSize ) {
 	this._isVertical = isVertical;
 	this._size = size;
+	this._grabSize = grabSize < size ? size : grabSize;
 
 	this.element = this._createElement();
 	this._dragListener = new lm.utils.DragListener( this.element );
@@ -16,9 +17,24 @@ lm.utils.copy( lm.controls.Splitter.prototype, {
 	},
 
 	_createElement: function() {
-		var element = $( '<div class="lm_splitter"><div class="lm_drag_handle"></div></div>' );
-		element.addClass( 'lm_' + ( this._isVertical ? 'vertical' : 'horizontal' ) );
-		element[ this._isVertical ? 'height' : 'width' ]( this._size );
+		var dragHandle = $( '<div class="lm_drag_handle"></div>' );
+		var element    = $( '<div class="lm_splitter"></div>' );
+		element.append(dragHandle);
+
+		var handleExcessSize = this._grabSize - this._size;
+		var handleExcessPos  = handleExcessSize / 2;
+
+		if( this._isVertical ) {
+			dragHandle.css( 'top', -handleExcessPos );
+			dragHandle.css( 'height', this._size + handleExcessSize );
+			element.addClass( 'lm_vertical' );
+			element[ 'height' ]( this._size );
+		} else {
+			dragHandle.css( 'left', -handleExcessPos );
+			dragHandle.css( 'width', this._size + handleExcessSize );
+			element.addClass( 'lm_horizontal' );
+			element[ 'width' ]( this._size );
+		}
 
 		return element;
 	}

--- a/src/js/items/RowOrColumn.js
+++ b/src/js/items/RowOrColumn.js
@@ -7,6 +7,7 @@ lm.items.RowOrColumn = function( isColumn, layoutManager, config, parent ) {
 	this.element = $( '<div class="lm_item lm_' + ( isColumn ? 'column' : 'row' ) + '"></div>' );
 	this.childElementContainer = this.element;
 	this._splitterSize = layoutManager.config.dimensions.borderWidth;
+	this._splitterGrabSize = layoutManager.config.dimensions.borderGrabWidth;
 	this._isColumn = isColumn;
 	this._dimension = isColumn ? 'height' : 'width';
 	this._splitter = [];
@@ -416,7 +417,7 @@ lm.utils.copy( lm.items.RowOrColumn.prototype, {
 	 */
 	_createSplitter: function( index ) {
 		var splitter;
-		splitter = new lm.controls.Splitter( this._isColumn, this._splitterSize );
+		splitter = new lm.controls.Splitter( this._isColumn, this._splitterSize, this._splitterGrabSize );
 		splitter.on( 'drag', lm.utils.fnBind( this._onSplitterDrag, this, [ splitter ] ), this );
 		splitter.on( 'dragStop', lm.utils.fnBind( this._onSplitterDragStop, this, [ splitter ] ), this );
 		splitter.on( 'dragStart', lm.utils.fnBind( this._onSplitterDragStart, this, [ splitter ] ), this );

--- a/src/js/utils/ConfigMinifier.js
+++ b/src/js/utils/ConfigMinifier.js
@@ -1,6 +1,7 @@
 /**
  * Minifies and unminifies configs by replacing frequent keys
- * and values with one letter substitutes
+ * and values with one letter substitutes. Config options must
+ * retain array position/index, add new options at the end.
  *
  * @constructor
  */
@@ -12,7 +13,6 @@ lm.utils.ConfigMinifier = function() {
 		'selectionEnabled',
 		'dimensions',
 		'borderWidth',
-		'borderGrabWidth',
 		'minItemHeight',
 		'minItemWidth',
 		'headerHeight',
@@ -36,7 +36,8 @@ lm.utils.ConfigMinifier = function() {
 		'openPopouts',
 		'parentId',
 		'activeItemIndex',
-		'reorderEnabled'
+		'reorderEnabled',
+		'borderGrabWidth',
 
 
 

--- a/src/js/utils/ConfigMinifier.js
+++ b/src/js/utils/ConfigMinifier.js
@@ -12,6 +12,7 @@ lm.utils.ConfigMinifier = function() {
 		'selectionEnabled',
 		'dimensions',
 		'borderWidth',
+		'borderGrabWidth',
 		'minItemHeight',
 		'minItemWidth',
 		'headerHeight',
@@ -36,7 +37,6 @@ lm.utils.ConfigMinifier = function() {
 		'parentId',
 		'activeItemIndex',
 		'reorderEnabled'
-
 
 
 

--- a/src/less/goldenlayout-base.less
+++ b/src/less/goldenlayout-base.less
@@ -62,9 +62,7 @@
   &.lm_vertical {
     .lm_drag_handle {
       width: @width0;
-      height: @height6;
       position: absolute;
-      top: -5px;
       cursor: ns-resize;
     }
   }
@@ -74,10 +72,8 @@
     height: @height0;
 
     .lm_drag_handle {
-      width: @width5;
       height: @height0;
       position: absolute;
-      left: -5px;
       cursor: ew-resize;
     }
   }


### PR DESCRIPTION
Following my further comments in issue #240, I've introduced a 'borderGrabWidth' config option to govern the size of the drag handle independently to the size of the splitter. This resolves both the problem of scroll bars (by configuration on the part of the integrator) and the fact that 'borderWidth' can actually break the layout currently because the drag handle is not resized with it.

This should be backwards compatible, at least in so much as it should not introduce new layout that is particularly unhelpful - at worst the user may find the draggable area has increased to 15px, but this is unlikely to be enough to cause real trauma. Anyone who has introduced CSS like that detailed in issue #240 will obviously find this ineffectual following the update, but again, the result is probably unlikely to be too unfriendly.

For docs:

argument			type		optional	default	description
borderGrabWidth	Number	true		15		The draggable area height, or width, of the borders between the layout items, in pixels. If set smaller than 'borderWidth', it will be increased to match it so that the draggable are is not smaller than the splitter itself.