### PR TITLE
Ensure that dragListener cleans up on destroy

### DIFF
--- a/src/js/controls/Tab.js
+++ b/src/js/controls/Tab.js
@@ -104,6 +104,7 @@ lm.utils.copy( lm.controls.Tab.prototype, {
 		this.closeElement.off( 'click touchstart', this._onCloseClickFn );
 		if( this._dragListener ) {
 			this._dragListener.off( 'dragStart', this._onDragStart );
+			this._dragListener.destroy();
 			this._dragListener = null;
 		}
 		this.element.remove();

--- a/src/js/utils/DragListener.js
+++ b/src/js/utils/DragListener.js
@@ -37,6 +37,10 @@ lm.utils.DragListener.timeout = null;
 lm.utils.copy( lm.utils.DragListener.prototype, {
 	destroy: function() {
 		this._eElement.unbind( 'mousedown touchstart', this._fDown );
+        this._oDocument.unbind( 'mouseup touchend', this._fUp );
+        this._eElement = null;
+        this._oDocument = null;
+        this._eBody = null;
 	},
 
 	onMouseDown: function( oEvent ) {


### PR DESCRIPTION
the document level bindings and the "touchend" event were hanging on to the whole context tree for the DragListener after a tab is closed, which includes the tab component, main content window, and other stuff. this is a pretty significant memory leak.