### PR TITLE
Take border/padding of component into account when calculating size.

### DIFF
--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -1742,7 +1742,11 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 		if( width !== this.width || height !== this.height ) {
 			this.width = width;
 			this.height = height;
-			this._contentElement.width( this.width ).height( this.height );
+			var cl = this._contentElement[0];
+			var hdelta = cl.offsetWidth - cl.clientWidth;
+			var vdelta = cl.offsetHeight - cl.clientHeight;
+			this._contentElement.width( this.width-hdelta )
+			     .height( this.height-vdelta );
 			this.emit( 'resize' );
 		}
 	}

--- a/src/js/container/ItemContainer.js
+++ b/src/js/container/ItemContainer.js
@@ -183,7 +183,11 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 		if( width !== this.width || height !== this.height ) {
 			this.width = width;
 			this.height = height;
-			this._contentElement.width( this.width ).height( this.height );
+			var cl = this._contentElement[0];
+			var hdelta = cl.offsetWidth - cl.clientWidth;
+			var vdelta = cl.offsetHeight - cl.clientHeight;
+			this._contentElement.width( this.width-hdelta )
+			     .height( this.height-vdelta );
 			this.emit( 'resize' );
 		}
 	}


### PR DESCRIPTION
If an lm_content object (in an lm_item_container) has non-zero border or padding, these need to be taken into consideration when calculating the width/height of the lm_content.  This change does that.

I don't really know jquery so there may be a cleaner way of making this change, but this seems to work.

I'm also unfamiliar with the world of grunt, gult, bower, or npm, so I haven't yet figured out how to rebuild things.