### PR TITLE
Emit activeContentItemChanged event on layoutManager as well.

### DIFF
--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -4437,6 +4437,7 @@ lm.utils.copy( lm.items.Stack.prototype, {
 		this.header.setActiveContentItem( contentItem );
 		contentItem._$show();
 		this.emit( 'activeContentItemChanged', contentItem );
+		this.layoutManager.emit( 'activeContentItemChanged', contentItem );
 		this.emitBubblingEvent( 'stateChanged' );
 	},
 

--- a/src/js/items/Stack.js
+++ b/src/js/items/Stack.js
@@ -90,6 +90,7 @@ lm.utils.copy( lm.items.Stack.prototype, {
 		this.header.setActiveContentItem( contentItem );
 		contentItem._$show();
 		this.emit( 'activeContentItemChanged', contentItem );
+		this.layoutManager.emit( 'activeContentItemChanged', contentItem );
 		this.emitBubblingEvent( 'stateChanged' );
 	},
 


### PR DESCRIPTION
Emit activeContentItemChanged event on layoutManager as well.
This makes it easier to listen to these events without having to manage separate listeners for each component.

I use this in [DomTerm](http://domterm.org/). It uses goldenlayout to manage multiple terminals.  When a tab is made active, the corresponding terminal should get keyboard focus.  Using a single listener on the layoutManager made do so much easier.

I'm also unfamiliar with the world of grunt, gult, bower, or npm, so I haven't yet figured out how to rebuild things.