### PR TITLE
Update contentElement size using outerWidth/outerHeight.

### DIFF
--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -1752,8 +1752,11 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 		if( width !== this.width || height !== this.height ) {
 			this.width = width;
 			this.height = height;
-			this._contentElement.outerWidth( width )
-			     .outerHeight( height );
+			var cl = this._contentElement[0];
+			var hdelta = cl.offsetWidth - cl.clientWidth;
+			var vdelta = cl.offsetHeight - cl.clientHeight;
+			this._contentElement.width( this.width-hdelta )
+			     .height( this.height-vdelta );
 			this.emit( 'resize' );
 		}
 	}

--- a/dist/goldenlayout.js
+++ b/dist/goldenlayout.js
@@ -1752,11 +1752,8 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 		if( width !== this.width || height !== this.height ) {
 			this.width = width;
 			this.height = height;
-			var cl = this._contentElement[0];
-			var hdelta = cl.offsetWidth - cl.clientWidth;
-			var vdelta = cl.offsetHeight - cl.clientHeight;
-			this._contentElement.width( this.width-hdelta )
-			     .height( this.height-vdelta );
+			this._contentElement.outerWidth( width )
+			     .outerHeight( height );
 			this.emit( 'resize' );
 		}
 	}

--- a/src/js/container/ItemContainer.js
+++ b/src/js/container/ItemContainer.js
@@ -183,11 +183,8 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 		if( width !== this.width || height !== this.height ) {
 			this.width = width;
 			this.height = height;
-			var cl = this._contentElement[0];
-			var hdelta = cl.offsetWidth - cl.clientWidth;
-			var vdelta = cl.offsetHeight - cl.clientHeight;
-			this._contentElement.width( this.width-hdelta )
-			     .height( this.height-vdelta );
+			this._contentElement.outerWidth( width )
+			     .outerHeight( height );
 			this.emit( 'resize' );
 		}
 	}


### PR DESCRIPTION
This fixes "scrollbar misplacement by width of scrollbar #342".
It is a improvement to the earlier patch "Take border/padding of
component into account when calculating size. #303"